### PR TITLE
fixes: words and precompile result checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@summa-tx/memview-sol",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Raw memory access in solidity",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:
- bug causing overreporting view memory usage in certain circumstances
- adds a safety check to precompile outputs